### PR TITLE
Update README with permissions and ownership setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ The platform supports a **multi-agent architecture** where you can deploy multip
 1. **Create directory structure:**
 
 ```bash
-mkdir -p traefik-dashboard/{data/{logs,geoip,positions,dashboard}}
+mkdir -p traefik-dashboard/data/{logs,geoip,positions,dashboard}
 cd traefik-dashboard
+chmod 755 data/geoip data/positions data/dashboard
+chown -R 1001:1001 ./data/dashboard
 ```
 
 2. **Create `docker-compose.yml`:**


### PR DESCRIPTION
Fixed folder creation command and added permissions and ownership commands for dashboard data.

Fixing 
```
traefik-log-dashboard        |  ⨯ SqliteError: unable to open database file
traefik-log-dashboard        |     at l (.next/server/chunks/219.js:1:534)
traefik-log-dashboard        |     at 36903 (.next/server/chunks/219.js:151:229)
traefik-log-dashboard        |     at c (.next/server/webpack-runtime.js:1:127)
traefik-log-dashboard        |     at 40334 (.next/server/app/api/logs/access/route.js:1:978)
traefik-log-dashboard        |     at c (.next/server/webpack-runtime.js:1:127)
traefik-log-dashboard        |     at <unknown> (.next/server/app/api/logs/access/route.js:1:7990)
traefik-log-dashboard        |     at c.X (.next/server/webpack-runtime.js:1:1191)
traefik-log-dashboard        |     at <unknown> (.next/server/app/api/logs/access/route.js:1:7968)
traefik-log-dashboard        |     at Object.<anonymous> (.next/server/app/api/logs/access/route.js:1:8022) {
traefik-log-dashboard        |   code: 'SQLITE_CANTOPEN'
traefik-log-dashboard        | }
```