### PR TITLE
Allow status code 0 to be added in FilterSettingsPage

### DIFF
--- a/dashboard/app/settings/filters/page.tsx
+++ b/dashboard/app/settings/filters/page.tsx
@@ -65,7 +65,7 @@ export default function FilterSettingsPage() {
 
   const handleAddStatusCode = () => {
     const code = parseInt(newStatusCode);
-    if (!isNaN(code) && code >= 100 && code < 600) {
+    if (!isNaN(code) && ((code >= 100 && code < 600) || code==0)) {
       updateSettings({
         excludeStatusCodes: [...settings.excludeStatusCodes, code],
       });


### PR DESCRIPTION
Status code filtering does not currently allow filtering by status code 0 (N/A). This is relevant, for example, if you want to filter WebSockets connections.

Replaces PR #133