### PR TITLE
Exclude logs with status 0 from duration calculations

### DIFF
--- a/cli/internal/logs/metrics.go
+++ b/cli/internal/logs/metrics.go
@@ -69,8 +69,11 @@ func CalculateMetrics(logs []TraefikLog) *Metrics {
 			metrics.Status5xx++
 		}
 
-		// Collect durations (convert ns to ms)
-		durations = append(durations, float64(log.Duration)/1000000)
+		// Exclude logs with status 0
+		if(log.DownstreamStatus != 0) {
+			// Collect durations (convert ns to ms)
+			durations = append(durations, float64(log.Duration)/1000000)
+		}	
 	}
 
 	// Calculate error rate

--- a/dashboard/lib/services/metric-snapshot-service.ts
+++ b/dashboard/lib/services/metric-snapshot-service.ts
@@ -104,7 +104,7 @@ function calculateSnapshotMetrics(
   }
 
   // Response time metrics
-  const durations = logs.map((l) => l.Duration / 1000000); // Convert to milliseconds
+  const durations = logs.filter(l=>l.DownstreamStatus!=0).map(l => l.Duration / 1000000); // Convert to milliseconds and exclude logs with status 0
   const avgDuration = calculateAverage(durations);
   const p95Duration = calculatePercentile(durations, 95);
   const p99Duration = calculatePercentile(durations, 99);

--- a/dashboard/lib/utils/metric-calculator.ts
+++ b/dashboard/lib/utils/metric-calculator.ts
@@ -13,7 +13,7 @@ export function calculateMetrics(logs: TraefikLog[], geoLocations: GeoLocation[]
   const perSecond = timeSpan > 0 ? total / timeSpan : 0;
 
   // Response time metrics
-  const durations = logs.map(l => l.Duration / 1000000); // Convert to milliseconds
+  const durations = logs.filter(l=>l.DownstreamStatus!=0).map(l => l.Duration / 1000000); // Convert to milliseconds and exclude logs with status 0
   const avgDuration = calculateAverage(durations);
   const p95Duration = calculatePercentile(durations, 95);
   const p99Duration = calculatePercentile(durations, 99);


### PR DESCRIPTION
Exclude log entries with status code 0 from the duration calculation. This is because a long lasting web socket connection is not an indication of poor performance. A long duration is to be expected. 

As suggested in PR #133.