### PR TITLE
Change working directory of `agent` to `/app`

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -31,7 +31,7 @@ FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates
 
-WORKDIR /root/
+WORKDIR /app/
 
 # Copy the binary from builder
 COPY --from=builder /app/main .


### PR DESCRIPTION
`/root` is a special folder that is the home of user `root` whose permission is `700` (no one can read that except `root` itself). Therefore, changing to `/app` will allow the agent to run as a non-root user.

<img width="830" height="193" alt="image" src="https://github.com/user-attachments/assets/6a1bab85-f587-496b-be74-bc009ba7e957" />
